### PR TITLE
Add support for indirect symbolic reference mangled names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Breakpoints_v2.xcbkptlist
 /.DS_Store
 /dsdump/.DS_Store
 .DS_Store
+xcuserdata
+swift-source

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ VERBOSITY
            1. 0 + Parent classes
            2. 1 + Protocols
            3. 2 + Swift type dump
-           4. 3 + Extednded type jump, ObjC bridge methods
+           4. 3 + Extended type dump, ObjC bridge methods
            5. 4 + Commenting in methods
 
      --objc:
@@ -137,20 +137,22 @@ Darwin                         October 20, 2019                         Darwin
 Compiling this will be a bit of a pain in the butt on your end. You'll need to clone the Swift language in the same directory. Swift can't be a submodule to this repo since some of their git cloning scripts won't work :| 
 
 ```bash
-# cd to the same directory as the dsdump repo
-cd dsdump/.. 
+# cd into the dsdump repo
+cd dsdump/
 
 # make a directory called swift-source, yes, name it exactly that
 mkdir swift-source
 
-# clone 
-git clone git@github.com:apple/swift.git
+cd swift-source/
+
+# clone the Swift repository into swift-source
+git clone https://github.com/apple/swift.git
 
 # checkout 
 git checkout 75670c17272a993ed798cee7e31c20590e94118b
 
-# Use the swift update helper script to grab everything else 
-./swift/utils/update-checkout --clone-with-ssh
+# Use the Swift update helper script to grab everything else 
+./swift/utils/update-checkout --clone
 ```
 Comment out any remaining problematic code after a build, remove methods in `Metadata.h` as needed (i.e. problematic ARC bridging code on line 700)
 

--- a/dsdump.xcodeproj/project.pbxproj
+++ b/dsdump.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 				3FD99904233E90FE0072F4A0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		A66A9CBC22316CF3006602AB /* Products */ = {
 			isa = PBXGroup;
@@ -859,8 +860,8 @@
 				);
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "";
 				HEADER_SEARCH_PATHS = (
-					"\"$(SRCROOT)/../swift-source/swift/include\"",
-					"\"$(SRCROOT)/../swift-source/llvm/include/\"",
+					"\"$(SRCROOT)/swift-source/swift/include\"",
+					"\"$(SRCROOT)/swift-source/llvm/include/\"",
 					"\"$(SRCROOT)/fix_swift\"",
 				);
 				LD_NO_PIE = YES;
@@ -891,8 +892,8 @@
 				DEVELOPMENT_TEAM = H4U46V6494;
 				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "";
 				HEADER_SEARCH_PATHS = (
-					"\"$(SRCROOT)/../swift-source/swift/include\"",
-					"\"$(SRCROOT)/../swift-source/llvm/include/\"",
+					"\"$(SRCROOT)/swift-source/swift/include\"",
+					"\"$(SRCROOT)/swift-source/llvm/include/\"",
 					"\"$(SRCROOT)/fix_swift\"",
 				);
 				LD_NO_PIE = YES;

--- a/dsdump/XRMachOLibrary+Swift.mm
+++ b/dsdump/XRMachOLibrary+Swift.mm
@@ -797,5 +797,5 @@ const char * resolveExternalTypeDescriptorIfNeeded(const char *base, bool &resol
         }
     }
     
-    return base ;
+    return base;
 }

--- a/dsdump/XRMachOLibrary+Swift.mm
+++ b/dsdump/XRMachOLibrary+Swift.mm
@@ -762,8 +762,14 @@ const char * resolveExternalTypeDescriptorIfNeeded(const char *base, bool &resol
     auto end = base;
     while (*end != '\0') {
         if (*end >= '\x01' && *end <= '\x17') {
-            end++;
-            contextDescriptor = (ContextDescriptor *)(*(int32_t *)(end) + (uintptr_t)end);
+            switch (*end++) {
+                case '\x01':
+                    contextDescriptor = (ContextDescriptor *)(*(int32_t *)(end) + (uintptr_t)end);
+                    break;
+                case '\x02':
+                    contextDescriptor = payload::DiskWrapper<ContextDescriptor>::Cast(*(uintptr_t *)(*(int32_t *)end + (uintptr_t)end))->disk();
+                    break;
+            }
             break;
 
         } else if (*end >= '\x18' && *end <= '\x1F') {

--- a/dsdump/dsdump.1
+++ b/dsdump/dsdump.1
@@ -67,7 +67,7 @@ dsdump can output a range of verbosity between the 3 different modes (--sym, --s
 .Dl 1. 0 + Parent classes
 .Dl 2. 1 + Protocols
 .Dl 3. 2 + Swift "type dump"
-.Dl 4. 3 + Extednded type jump, ObjC bridge methods
+.Dl 4. 3 + Extended type dump, ObjC bridge methods
 .Dl 5. 4 + Commenting in methods
 .Pp
 --objc:

--- a/dsdump/main.m
+++ b/dsdump/main.m
@@ -47,7 +47,7 @@ int main(int argc, const char * argv[], const char*envp[]) {
     }
     char resolved_path[PATH_MAX];
     if (!realpath(_path, resolved_path)) {
-        printf("Couldn't resolved \"%s\"\n", _path);
+        printf("Couldn't resolve \"%s\"\n", _path);
         exit(1);
     }
     NSString *path = [NSString stringWithUTF8String:resolved_path];


### PR DESCRIPTION
The Swift compiler emits indirect symbolic references in certain cases which cause dsdump to behave undesirably when it encounters them. This pull request fixes that. It also contains some assorted changes that I made to make my life better/easier; feel free to pick and choose the parts you want or ask me why I changed something.